### PR TITLE
Fix package name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
         <li class="p-inline-list__item"><a href="/docs" class="p-button--positive u-no-margin--bottom-small">Read the Dqlite docs</a></li>
         <li class="p-inline-list__item"><a href="https://github.com/canonical/dqlite/releases" class="p-button u-no-margin--bottom-small" aria-label="External link to the Dqlite releases page on Github">Download Dqlite</a></li>
       </ul>
-      <p>install on Ubuntu (bleeding edge): <div class="p-code-snippet"><pre class="p-code-snippet__block--icon"><code>sudo add-apt-repository -y ppa:dqlite/dev && sudo apt install dqlite</code></pre></div></p>
+      <p>install on Ubuntu (bleeding edge): <div class="p-code-snippet"><pre class="p-code-snippet__block--icon"><code>sudo add-apt-repository -y ppa:dqlite/dev && sudo apt install dqlite-tools</code></pre></div></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
See https://github.com/canonical/dqlite/issues/497. Maybe we should reintroduce a `dqlite` package that has all the others as dependencies?

Signed-off-by: Cole Miller <cole.miller@canonical.com>