### PR TITLE
Add CI steps to support 12 factor charm deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,89 @@
+name: Deploy site
+
+on: 
+  push:
+    branches: 
+      - main
+
+env:
+  CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
+  ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
+
+jobs:
+  pack-charm:
+    runs-on: ubuntu-latest      
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Setup Charmcraft
+        run: sudo snap install charmcraft --classic --channel=edge/12f
+
+      - name: Pack charm
+        run: charmcraft pack -v --project-dir ./charm
+
+      - name: Upload charm
+        uses: actions/upload-artifact@v3
+        with:
+          name: dqlite-io-charm
+          path: ./*.charm
+
+  pack-rock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+
+      - name: Build Assets
+        run: |
+          yarn install
+          yarn run build-css
+          yarn run build-js
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Setup Rockcraft
+        run: sudo snap install rockcraft --classic --channel=edge/12f
+
+      - name: Pack Rock
+        run: rockcraft pack
+
+      - name: Upload Rock
+        uses: actions/upload-artifact@v3
+        with:
+          name: dqlite-io-rock
+          path: ./*.rock
+
+  publish-image:
+    runs-on: ubuntu-latest
+    needs: pack-rock
+    outputs:
+      image_url: ${{ steps.set_image_url.outputs.image_url }}
+    steps:
+      - name: Get Rock
+        uses: actions/download-artifact@v3
+        with:
+          name: dqlite-io-rock
+      
+      - name: Set image URL
+        id: set_image_url
+        run: echo "image_url=ghcr.io/canonical/dqlite.io:$(date +%s)-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
+      - name: Push to GHCR
+        run: skopeo --insecure-policy copy oci-archive:$(ls *.rock) docker://${{ steps.set_image_url.outputs.image_url }} --dest-creds "canonical:${{ secrets.GITHUB_TOKEN }}"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [pack-charm, publish-image]
+    steps:
+      - name: Workflow run ID
+        run : echo ${{ github.run_id }}
+      - name: Image URL
+        run : echo ${{ needs.publish-image.outputs.image_url }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,6 @@ env:
 jobs:
   run-dotrun:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Done

Add CI steps to pack both the charm and the rock for dqlite.io and then publish the container image go ghcr.io.