### PR TITLE
Update canonicalwebteam.discourse to 5.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.7
+canonicalwebteam.discourse==5.5.0
 canonicalwebteam.search==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.search==1.3.0


### PR DESCRIPTION
## Done

- Update canonicalwebteam.discourse to 5.5.0

## QA

- Go to https://dqlite-io-296.demos.haus/docs
- Inspect a heading (h2 and down) and see the anchor link within it doesn't have trailing number

