### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postcss": "8.4.20",
     "postcss-cli": "10.1.0",
     "sass": "1.57.1",
-    "vanilla-framework": "4.5.1",
+    "vanilla-framework": "4.14.0",
     "webpack-cli": "4.10.0"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.7
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.search==1.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5612,10 +5612,10 @@ vanilla-framework@3.14.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.14.0.tgz#c5b94d7e2e3ef2d3c9f24091b7efc4abf8054cf9"
   integrity sha512-06Vr2nhjU72N9IivwCLcd7FgqFNopkiHfzANJUCNdvs8FkbTjIB7fcsFgJ6O76KnOBsEiAoJAssRkTh9x3a2jw==
 
-vanilla-framework@4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.5.1.tgz#19b55dd4771c304b2bae8af646312916f5f45917"
-  integrity sha512-vF7GGZsXcQZnM2522Q2am08to/iM2K+EhsfYPuYsiHvp2kRGxY/rJ8tcjbKftNY859qOqT8yJg0PE+sVmKI5zg==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

## QA

- Check nothing the changes in vanilla have not broken anything
- Go to docs and hover over a h2 heading, see the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) works as expected
- Inspect the heading and see there are no trailing numbers on the heading 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12932