### PR TITLE
chore: Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postcss": "8.4.20",
     "postcss-cli": "10.1.0",
     "sass": "1.57.1",
-    "vanilla-framework": "4.14.0",
+    "vanilla-framework": "4.16.0",
     "webpack-cli": "4.10.0"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==2.1.0
+canonicalwebteam.search==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -47,7 +47,7 @@ app.add_url_rule(
         session=session,
         site="https://dqlite.io/docs",
         template_path="docs/search.html",
-        request_limit="1/day"
+        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -47,7 +47,6 @@ app.add_url_rule(
         session=session,
         site="https://dqlite.io/docs",
         template_path="docs/search.html",
-        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,9 +43,11 @@ app.add_url_rule(
     "/docs/search",
     "docs-search",
     build_search_view(
+        app=app,
         session=session,
         site="https://dqlite.io/docs",
         template_path="docs/search.html",
+        request_limit="1/day"
     ),
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5612,10 +5612,10 @@ vanilla-framework@3.14.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.14.0.tgz#c5b94d7e2e3ef2d3c9f24091b7efc4abf8054cf9"
   integrity sha512-06Vr2nhjU72N9IivwCLcd7FgqFNopkiHfzANJUCNdvs8FkbTjIB7fcsFgJ6O76KnOBsEiAoJAssRkTh9x3a2jw==
 
-vanilla-framework@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
-  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+vanilla-framework@4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
+  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Upgrade canonicalwebteam.search to 2.1.0
- Pass `app` to `build_search_view()`
- Bump vanilla-framework to 4.16.0

## QA

- Go to https://dqlite-io-302.demos.haus/docs/search
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15007

## Screenshots

![image](https://github.com/user-attachments/assets/9d3af5d2-71c2-43bd-a167-e1bc2dc869e4)
