### PR TITLE
Invoke cookie policy before gtm

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -9,6 +9,13 @@
     </title>
     <link rel="preconnect" href="https://www.google-analytics.com" />
     <link rel="preconnect" href="https://www.gstatic.com" />
+    <!-- Cookie policy -->
+    <script src="{{ versioned_static('js/build/cookie-policy/cookie-policy.js') }}"></script>
+    <script>
+      if (typeof cpNs !== "undefined") {
+          cpNs.cookiePolicy();
+        }
+    </script>
     <!-- Google Tag Manager -->
     <script>(function (w, d, s, l, i) {
       w[l] = w[l] || []; w[l].push({
@@ -94,11 +101,7 @@
       {% include "partial/_footer.html" %}
     {% endblock body %}
     <script src="{{ versioned_static('js/build/global-nav/global-nav.js') }}"></script>
-    <script src="{{ versioned_static('js/build/cookie-policy/cookie-policy.js') }}"></script>
     <script>
-    if (typeof cpNs !== "undefined") {
-        cpNs.cookiePolicy();
-      }
     if (typeof canonicalGlobalNav !== "undefined") {
       canonicalGlobalNav.createNav({breakpoint: 940});
     }


### PR DESCRIPTION
## Done

- Call cookie policy script before invoking gtm

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8037
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
