### PR TITLE
[WD-18788] chore: redirect dqlite.io to canonical.com/dqlite

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,6 @@ env:
   SECRET_KEY: insecure_test_key
   FLASK_GOOGLE_SEARCH_API_KEY: insecure_test_key
 jobs:
-
   run-dotrun:
     runs-on: ubuntu-22.04
 
@@ -57,7 +56,7 @@ jobs:
         run: yarn lint-scss
 
   test-python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,3 @@
+/: "https://canonical.com/dqlite"
+/docs/?: "https://canonical.com/dqlite/docs"
+/docs/(?P<page>.*)/?: "https://canonical.com/dqlite/docs/{page}"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,7 +16,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/").status_code, 200)
+        self.assertEqual(self.client.get("/").status_code, 302)
 
     def test_not_found(self):
         """


### PR DESCRIPTION
## Done

- Added redirects.yaml file
- Added redirects from /* to canonical.com/dqlite/*

## QA

- View the site locally in your web browser at: https://dqlite-io-322.demos.haus
- Make sure it is redirected to canonical.com/dqlite
- Make sure https://dqlite-io-322.demos.haus/docs is redirected to canonical.com/dqlite/docs
- Make sure https://dqlite-io-322.demos.haus/docs/tutorials/setup-your-development-environment is redirected to canonical.com/dqlite/docs/tutorials/setup-your-development-environment


## Issue / Card

Fixes #[WD-18788](https://warthogs.atlassian.net/browse/WD-18788)

[WD-18788]: https://warthogs.atlassian.net/browse/WD-18788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ